### PR TITLE
Ignore stderr

### DIFF
--- a/src/r2.ml
+++ b/src/r2.ml
@@ -40,7 +40,7 @@ let open_file f_name =
         (out_r, out_w),
         (_, err_w) = Unix.(pipe (), pipe (), pipe ())
     in
-    let args = [|"r2"; "-q0"; f_name|] in
+    let args = [|"r2"; "-2"; "-q0"; f_name|] in
     let pid = Unix.create_process "r2" args ins_r out_w err_w in
     (* Get rid of the beginning \x00 *)
     ignore (Unix.read out_r (Bytes.create 1) 0 1);


### PR DESCRIPTION
Currently if you have "broken" file and r2 will complain with warnings in the stderr it will clogs the output,
just disabling stderr for now is the simplest solution.