### PR TITLE
enables large integers in the JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Here's a utop session, (`opam install utop`)
 ```ocaml
 #require "radare2";;
 let result = R2.with_command_j ~cmd:"/j chown" "/bin/ls";;
-val result : Yojson.Basic.json =
-`List 
+val result : Yojson.t =
+`List
   [`Assoc
     [("offset", `Int 4294987375); ("id:", `Int 0);
      ("data", `String "ywritesecuritychownfile_inheritdi")]]"
@@ -67,7 +67,7 @@ val command : r2:r2 -> string -> string
 (** Send a command to r2, get back Yojson. If output isn't JSON
     parsable then raises {Invalid_argument} so make sure command ends
     with 'j' *)
-val command_json : r2:r2 -> string -> Yojson.Basic.t
+val command_json : r2:r2 -> string -> Yojson.t
 
 (** Create a r2 instance with a given file, raises {Invalid_argument}
     if file doesn't exists *)
@@ -82,4 +82,5 @@ val with_command : cmd:string -> string -> string
 
 (** Convenience function for opening a r2 instance, sending a command,
     getting the result as Yojson and closing the r2 instance *)
-val with_command_j : cmd:string -> string -> Yojson.Basic.t```
+val with_command_j : cmd:string -> string -> Yojson.t
+```

--- a/r2.ml
+++ b/r2.ml
@@ -24,9 +24,12 @@ let send_command {write_to; read_from; _} cmd =
 
 let command ~r2 cmd = send_command r2 cmd
 
+let parse_json s =
+  (Yojson.Safe.from_string s :> Yojson.t)
+
 let command_json ~r2 cmd =
   try
-    send_command r2 cmd |> Yojson.Basic.from_string
+    send_command r2 cmd |> parse_json
   with
     Yojson.Json_error _ ->
     raise (Invalid_argument "Output wasn't JSON parsable, \
@@ -62,4 +65,4 @@ let with_command_j ~cmd f_name =
   let r2 = open_file f_name in
   let output = command ~r2 cmd in
   close r2;
-  output |> Yojson.Basic.from_string
+  output |> parse_json

--- a/r2.mli
+++ b/r2.mli
@@ -9,7 +9,7 @@ val command : r2:r2 -> string -> string
 (** Send a command to r2, get back Yojson. If output isn't JSON
     parsable then raises {Invalid_argument} so make sure command ends
     with 'j' *)
-val command_json : r2:r2 -> string -> Yojson.Basic.t
+val command_json : r2:r2 -> string -> Yojson.t
 
 (** Create a r2 instance with a given file, raises {Invalid_argument}
     if file doesn't exists *)
@@ -24,4 +24,4 @@ val with_command : cmd:string -> string -> string
 
 (** Convenience function for opening a r2 instance, sending a command,
     getting the result as Yojson and closing the r2 instance *)
-val with_command_j : cmd:string -> string -> Yojson.Basic.t
+val with_command_j : cmd:string -> string -> Yojson.t

--- a/radare2.opam
+++ b/radare2.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "radare2"
-version: "0.0.4"
+version: "0.0.5"
 maintainer: "Edgar Aroutiounian <edgar.factorial@gmail.com>"
 authors: [ "Edgar Aroutiounian <edgar.factorial@gmail.com>" ]
 license: "BSD-3-Clause"


### PR DESCRIPTION
The Json.Basic doesn't support large integers which are common in
binary analysis. The PR proposes to switch to the Yojson.Stable.t
interface for parsing and to use Yojson.t as the output type to enable
interface stability.